### PR TITLE
Ensure validate! actually halts the perform method

### DIFF
--- a/lib/interaction/validation_helpers.rb
+++ b/lib/interaction/validation_helpers.rb
@@ -8,7 +8,7 @@ module Interaction::ValidationHelpers
   # @since 0.0.1
   # @api public
   def validate!
-    failure unless valid?
+    failure! unless valid?
   end
 
   # Merges errors from another

--- a/spec/interaction/validation_helpers_spec.rb
+++ b/spec/interaction/validation_helpers_spec.rb
@@ -12,11 +12,12 @@ describe Interaction::ValidationHelpers do
         ActiveModel::Name.new(self, nil, "Test")
       end
 
-      attr_accessor :name
+      attr_accessor :name, :result
       validates :name, presence: true
 
       def perform
         validate!
+        @result = true
       end
 
       public :merge_errors
@@ -45,12 +46,15 @@ describe Interaction::ValidationHelpers do
       let(:params) { {} }
 
       it { should_not be_success }
+      it { expect(use_case.result).to be_nil }
     end
 
     context 'when validation succeeds' do
       let(:params) { { name: 'Test' } }
 
       it { should be_success }
+
+      it { expect(use_case.result).to eq(true) }
     end
   end
 end


### PR DESCRIPTION
This change will ensure an exception is raise when `validate!` is called.

```console
$ be rspec
..................

Finished in 0.07642 seconds (files took 0.16075 seconds to load)
18 examples, 0 failures
```